### PR TITLE
Add check for executable installed by distribution

### DIFF
--- a/jarbas_wake_word_plugin_precise/__init__.py
+++ b/jarbas_wake_word_plugin_precise/__init__.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import distutils.spawn
 from mycroft.client.speech.hotword_factory import HotWordEngine
 from os.path import join, isfile, expanduser, isdir, dirname
 from petact import install_package
@@ -34,7 +35,9 @@ class PreciseHotwordPlugin(HotWordEngine):
         trigger_level = self.config.get('trigger_level', 3)
         sensitivity = self.config.get('sensitivity', 0.5)
         version = self.config.get("version", 0.2)
-        precise_exe = self.config.get("binary_path")
+
+        dist_exe = distutils.spawn.find_executable("precise-engine")
+        precise_exe = self.config.get("binary_path", dist_exe)
         model = self.config.get('model')
 
         if not precise_exe:

--- a/jarbas_wake_word_plugin_precise/__init__.py
+++ b/jarbas_wake_word_plugin_precise/__init__.py
@@ -12,7 +12,7 @@
 #
 import distutils.spawn
 from mycroft.client.speech.hotword_factory import HotWordEngine
-from os.path import join, isfile, expanduser, isdir, dirname
+from os.path import join, isfile, expanduser, isdir
 from petact import install_package
 import platform
 from xdg import BaseDirectory


### PR DESCRIPTION
Basically uses the distutils find_exec to check the normal path for the
executable.

Custom executables can still be used but download won't start if a
distribution executable is found.

Can be used with the mycroft-precise debian package in the [mycroft-desktop-repo](https://github.com/forslund/mycroft-desktop-repo) And might be useful for others trying to package Mycroft.

Edit: Also, Happy New Year!